### PR TITLE
Enable on-page editing and tidy achievements

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>IPSC — Ultra v5 (Clarity + Animations)</title>
+  <title>Ispahani Cantonment Public School & College</title>
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Bengali:wght@400;600;700&family=Inter:wght@500;700;900&display=swap" rel="stylesheet">
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/lottie-web/5.12.2/lottie.min.js"></script>
@@ -19,28 +19,40 @@
     .ghost{border:1px solid #e2e8f0;padding:.5rem 1rem;border-radius:.8rem;font-weight:700;text-decoration:none}
     .hamb{display:inline-flex;border:1px solid #e2e8f0;border-radius:.8rem;padding:.4rem .6rem}@media(min-width:768px){.hamb{display:none}}.mob{border-top:1px solid #e2e8f0;background:#fff}.mlink{display:block;padding:.7rem 1rem;text-decoration:none;font-weight:700}.mlink.special{background:linear-gradient(120deg,var(--brand),var(--brand2));color:#fff;border-radius:.6rem;margin:.5rem 1rem;text-align:center}
     .mega{position:relative}.mega .panel{position:absolute;left:50%;transform:translateX(-50%) translateY(8px);top:100%;width:min(640px,92vw);background:#fff;border:1px solid #e2e8f0;border-radius:1rem;box-shadow:0 24px 60px rgba(2,6,23,.15);padding:1rem;display:grid;grid-template-columns:1fr 1fr;gap:1rem;opacity:0;visibility:hidden;transition:.18s;z-index:50}.mega .panel .col h4{font-weight:800;font-size:.85rem;margin-bottom:.3rem}.mega .panel .col a{display:block;padding:.25rem .5rem;border-radius:.5rem;text-decoration:none;color:var(--ink)}.mega .panel .col a:hover{background:#f1f5f9}.mega.show .panel{opacity:1;visibility:visible;transform:translateX(-50%) translateY(0)}
-    .ticker{background:#0f172a;color:#e2e8f0;border-bottom:1px solid #1f2937}.ticker .wrap{overflow:hidden}.ticker-track{display:flex;gap:2rem;white-space:nowrap;animation:t 26s linear infinite}.ticker:hover .ticker-track{animation-play-state:paused}.tick{color:#93c5fd;text-decoration:none;padding:.5rem 0}@keyframes t{from{transform:translateX(0)}to{transform:translateX(-50%)}}
-    .section{padding:2.2rem 0}.head{display:flex;align-items:center;justify-content:space-between;gap:1rem;margin:.8rem 0}.head h2{font-size:1.6rem;font-weight:900}.muted{color:#64748b}.section-tag{display:inline-block;font-size:.75rem;font-weight:800;color:#0ea5e9;background:#e0f2fe;border:1px solid #bae6fd;border-radius:.5rem;padding:.15rem .5rem}
+    .ticker{position:sticky;top:64px;z-index:40;background:#0f172a;color:#e2e8f0;border-bottom:1px solid #1f2937}.ticker .wrap{overflow:hidden}.ticker-track{display:flex;gap:2rem;white-space:nowrap;animation:t 26s linear infinite}.ticker:hover .ticker-track{animation-play-state:paused}.tick{color:#93c5fd;text-decoration:none;padding:.5rem 0}@keyframes t{from{transform:translateX(0)}to{transform:translateX(-50%)}}
+    .section{padding:2.2rem 0}.head{display:flex;align-items:center;justify-content:space-between;gap:1rem;margin:.8rem 0}.head h2{font-size:1.6rem;font-weight:900}.head .title{display:flex;align-items:center;gap:.5rem}.muted{color:#64748b}.section-tag{display:inline-block;font-size:.75rem;font-weight:800;color:#0ea5e9;background:#e0f2fe;border:1px solid #bae6fd;border-radius:.5rem;padding:.15rem .5rem}
     .display{font-size:clamp(1.8rem,3.6vw,3rem);font-weight:900;letter-spacing:-.02em}.grad{background:linear-gradient(120deg,var(--brand),var(--brand2));-webkit-background-clip:text;color:transparent}.lede{margin-top:.6rem;color:#475569;max-width:58ch}.btns{margin-top:1rem;display:flex;gap:.6rem;flex-wrap:wrap}.stats{margin-top:1rem;display:flex;gap:.5rem;flex-wrap:wrap}.pill{background:#fff;border:1px solid #e2e8f0;padding:.4rem .6rem;border-radius:999px;font-weight:700}.lottie{width:100%;aspect-ratio:16/10;background:#fff;border:1px solid #e2e8f0;border-radius:1rem;box-shadow:0 20px 40px rgba(2,6,23,.08)}.anim-caption{display:grid;gap:.35rem}.anim-caption figcaption{font-size:.8rem;color:#64748b}
     .cards{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:1rem}@media(max-width:900px){.cards{grid-template-columns:1fr}}.card{background:#fff;border:1px solid #e2e8f0;border-radius:1rem;padding:1rem;box-shadow:0 8px 16px rgba(2,6,23,.06)}.card.pop{transition:.2s}.card.pop:hover{transform:translateY(-3px);box-shadow:0 16px 32px rgba(2,6,23,.12)}.bul{margin:.3rem 0 0 1rem}
     .timeline{border-left:3px solid #e2e8f0;margin-left:1rem;display:grid;gap:1rem}.timeline li{position:relative;list-style:none}.timeline .dot{position:absolute;left:-9px;top:.6rem;width:14px;height:14px;background:linear-gradient(120deg,var(--brand),var(--brand2));border-radius:50%}.timeline .card{margin-left:.5rem}
-    .leaders{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:1rem}.leader{background:#fff;border:1px solid #e2e8f0;border-radius:1rem;overflow:hidden}.leader img{width:100%;display:block}.leader .info{padding:.8rem 1rem;display:grid;gap:.25rem}.leader .name{font-weight:700}.leader .chip{display:inline-flex;padding:.35rem .6rem;border:1px solid #e2e8f0;border-radius:.6rem;text-decoration:none;font-weight:700}
+    .leaders{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:1rem}@media(max-width:900px){.leaders{grid-template-columns:1fr}}.leader{background:#fff;border:1px solid #e2e8f0;border-radius:1rem;overflow:hidden}.leader img{width:100%;display:block}.leader .info{padding:.8rem 1rem;display:grid;gap:.25rem;text-align:center}.leader .name{font-weight:700}.leader .chip{display:inline-flex;padding:.35rem .6rem;border:1px solid #e2e8f0;border-radius:.6rem;text-decoration:none;font-weight:700}
     .counters{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:1rem}.counter{background:#fff;border:1px solid #e2e8f0;border-radius:1rem;padding:1rem;text-align:center}.counter span{display:block;font-size:2rem;font-weight:900}.counter label{color:#64748b;font-weight:700}
     .gallery-block{margin-top:1rem}.gtitle{font-weight:800;margin-bottom:.4rem}.strip{display:flex;gap:.6rem;overflow:hidden}.strip img{width:260px;height:160px;object-fit:cover;border-radius:.75rem;box-shadow:0 6px 16px rgba(2,6,23,.08)}
     .quiz .qtext{font-weight:900;font-size:1.1rem;margin-bottom:.6rem}.qopts{display:grid;gap:.5rem}.qopts button{text-align:left;border:1px solid #e2e8f0;background:#fff;padding:.6rem .75rem;border-radius:.7rem;font-weight:700}.qopts button.correct{border-color:#22c55e}.qopts button.wrong{border-color:#ef4444}.qactions{display:flex;gap:.5rem;margin-top:.6rem}.qmeta{margin-top:.5rem;color:#64748b;font-size:.9rem}
     .divider.wave{height:56px;background:url('data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 1200 120\"><path d=\"M0 0h1200v60c-200 40-400 40-600 0s-400-40-600 0V0z\" fill=\"%23e2e8f0\"/></svg>') center/cover no-repeat}.divider.wave.flip{transform:scaleY(-1)}
-    .footer{border-top:1px solid #e2e8f0;background:#fff}.footer .wrap{padding:1.2rem 1rem;display:flex;justify-content:space-between;font-size:.9rem;color:#64748b}
-    .dark body{background:linear-gradient(to bottom,#0b1220,#0f172a);color:#e2e8f0}.dark .header{background:rgba(15,23,42,.93);border-color:#1f2937}.dark .ticker{background:#0b1325;color:#cbd5e1;border-color:#1f2937}.dark .tick{color:#93c5fd}.dark .card,.dark .lottie{background:#0f172a;border-color:#1f2937}.dark .pill{background:#0b1220;border-color:#1f2937;color:#d1d5db}.dark .timeline{border-color:#1f2937}.dark .link{color:#7dd3fc}.dark .divider.wave{background:url('data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 1200 120\"><path d=\"M0 0h1200v60c-200 40-400 40-600 0s-400-40-600 0V0z\" fill=\"%231f2937\"/></svg>') center/cover no-repeat}.dark .section-tag{background:#083344;border-color:#164e63;color:#7dd3fc}
-    @media(max-width:640px){.display{font-size:1.6rem}.strip img{width:220px;height:140px}}
+    .footer{border-top:1px solid #e2e8f0;background:#fff}.footer .wrap{padding:1.2rem 1rem;display:flex;justify-content:center;font-size:.9rem;color:#64748b}
+    .dark body{background:linear-gradient(to bottom,#0b1220,#0f172a);color:#e2e8f0}.dark .header{background:rgba(15,23,42,.93);border-color:#1f2937}.dark .brand{color:#f1f5f9}.dark .btext span{color:#94a3b8}.dark .ticker{background:#0b1325;color:#cbd5e1;border-color:#1f2937}.dark .tick{color:#93c5fd}.dark .card,.dark .lottie{background:#0f172a;border-color:#1f2937}.dark .pill{background:#0b1220;border-color:#1f2937;color:#d1d5db}.dark .timeline{border-color:#1f2937}.dark .link{color:#7dd3fc}.dark .divider.wave{background:url('data:image/svg+xml;utf8,<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 1200 120\"><path d=\"M0 0h1200v60c-200 40-400 40-600 0s-400-40-600 0V0z\" fill=\"%231f2937\"/></svg>') center/cover no-repeat}.dark .section-tag{background:#083344;border-color:#164e63;color:#7dd3fc}.dark .muted{color:#94a3b8}.dark .lede,.dark .counter label,.dark .gtitle{color:#cbd5e1}.dark h2,.dark h3,.dark p,.dark label,.dark .nav-btn,.dark .mlink,.dark .tlink{color:#f1f5f9}
+    .editing [contenteditable]{outline:1px dashed #0ea5e9}.editing img{outline:1px dashed #0ea5e9;cursor:pointer}
+    @media(max-width:640px){.display{font-size:1.6rem}.strip img{width:220px;height:140px}.header .wrap{padding:.5rem .75rem}.ticker{top:64px}.counters{grid-template-columns:1fr}}
   </style>
 </head>
 <body class="bg-gradient-to-b from-[#f8fbff] to-[#eef6ff] text-slate-800 selection:bg-[#ffd166]/60">
-  <div class="topbar"><div class="wrap"><div class="left"><span>EIIN 105826</span><span>College 7925</span><span>School 7801</span></div><div class="right"><button id="modeToggle" class="tbtn" aria-label="Toggle theme">☾</button></div></div></div>
+  <div class="topbar"><div class="wrap"><div class="left"><span>EIIN 105826</span><span>College 7925</span><span>School 7801</span></div><div class="right"><button id="editToggle" class="tbtn" aria-label="Toggle edit">✎</button><button id="saveBtn" class="tbtn hidden" aria-label="Save edits">💾</button><button id="modeToggle" class="tbtn" aria-label="Toggle theme">☾</button></div></div></div>
+  <div id="loginModal" class="fixed inset-0 bg-black/60 hidden items-center justify-center z-50">
+    <div class="bg-white dark:bg-[#0f172a] p-6 rounded-xl w-80 shadow">
+      <h3 class="font-bold mb-4 text-center">Admin Login</h3>
+      <label class="block mb-2 text-sm">Token</label>
+      <input id="tokenInput" type="password" class="w-full border border-gray-300 dark:border-gray-700 bg-white dark:bg-[#0b1220] p-2 rounded">
+      <div class="mt-4 flex justify-end gap-2">
+        <button id="loginCancel" class="ghost">Cancel</button>
+        <button id="loginOk" class="cta">Login</button>
+      </div>
+    </div>
+  </div>
   <header class="header">
     <div class="wrap">
       <a href="#" class="brand">
-        <svg width="44" height="44" viewBox="0 0 44 44" aria-hidden="true"><defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#2563eb"/><stop offset="1" stop-color="#22c55e"/></linearGradient></defs><circle cx="22" cy="22" r="20" fill="url(#g)"/><text x="22" y="29" text-anchor="middle" font-family="Inter,Arial" font-size="22" font-weight="900" fill="#fff">I</text></svg>
-        <div class="btext"><strong>Ispahani Public School & College</strong><span>Cumilla Cantonment</span></div>
+        <img id="logoImg" src="https://img.icons8.com/fluency/44/school.png" alt="Logo">
+        <div class="btext"><strong>Ispahani Cantonment Public School & College</strong><span>Cumilla Cantonment</span></div>
       </a>
       <nav class="nav" aria-label="Primary">
         <div class="mega"><button class="nav-btn" aria-haspopup="true">About</button><div class="panel two"><div class="col"><h4>Overview</h4><a href="#welcome">Welcome</a><a href="#leadership">Leadership</a><a href="#history">History</a></div><div class="col"><h4>Contact</h4><a href="#contact">Campus</a><a href="#contact">Location & Map</a><a href="#contact">Email & Phone</a></div></div></div>
@@ -57,7 +69,7 @@
 
   <div class="ticker" role="region" aria-label="Latest notices"><div class="wrap"><div id="tickerTrack" class="ticker-track"><a href="#" class="tick">একাদশ শ্রেণিতে ভর্তি (২০২৫–২৬) — Apply now</a><a href="#" class="tick">HSC Model Test Routine — Download PDF</a><a href="#" class="tick">Science Fair — Registration open (Robotics, IoT, AI)</a><a href="#" class="tick">Holiday Notice — Campus closed on Friday</a></div></div></div>
 
-  <section class="hero" id="welcome"><div class="wrap grid lg:grid-cols-12 gap-10 items-center"><div class="lg:col-span-6"><span class="section-tag">Welcome</span><h1 class="display">শিখো স্মার্টভাবে, <span class="grad">অর্জন করো প্রতিদিন।</span></h1><p class="lede">পড়াশোনা • শৃঙ্খলা • চরিত্র — IPSC ক্যাম্পাসে প্রযুক্তিতে সমৃদ্ধ শিক্ষানুভূতি।</p><div class="btns"><a class="cta" href="#notices">সর্বশেষ নোটিশ</a><a class="ghost" href="#gallery">গ্যালারি</a><a class="ghost" href="#brain">Brain Challenge</a></div><div class="stats"><div class="pill">৫৬+ বছর</div><div class="pill">১২+ ক্লাব</div><div class="pill">১০K+ অ্যালামনাই</div></div></div><div class="lg:col-span-6"><figure class="anim-caption"><figcaption>Study in Focus</figcaption><div id="lottie-hero" class="lottie"></div></figure></div></div></section>
+  <section class="hero" id="welcome"><div class="wrap grid lg:grid-cols-12 gap-10 items-center"><div class="lg:col-span-6"><span class="section-tag">Welcome</span><h1 class="display">শিখো স্মার্টভাবে, <span class="grad">অর্জন করো প্রতিদিন।</span></h1><p class="lede">পড়াশোনা • শৃঙ্খলা • চরিত্র — Ispahani Cantonment Public School & College ক্যাম্পাসে প্রযুক্তিতে সমৃদ্ধ শিক্ষানুভূতি।</p><div class="btns"><a class="cta" href="#notices">সর্বশেষ নোটিশ</a><a class="ghost" href="#gallery">গ্যালারি</a><a class="ghost" href="#brain">Brain Challenge</a></div><div class="stats"><div class="pill">৫৬+ বছর</div><div class="pill">১২+ ক্লাব</div><div class="pill">১০K+ অ্যালামনাই</div></div></div><div class="lg:col-span-6"><figure class="anim-caption"><figcaption>Study in Focus</figcaption><div id="lottie-hero" class="lottie"></div></figure></div></div></section>
   <div class="divider wave" aria-hidden="true"></div>
 
   <section id="notices" class="section"><div class="wrap"><span class="section-tag">Notices</span><div class="head"><h2>নোটিশ</h2><a class="link" href="#">সব নোটিশ →</a></div><ol class="timeline"><li><div class="dot"></div><div class="card"><h3>একাদশ শ্রেণিতে ভর্তি বিজ্ঞপ্তি (২০২৫–২০২৬)</h3><p>নির্ধারিত সময়ের মধ্যে অনলাইনে আবেদন করুন। প্রয়োজনীয় কাগজপত্রের তালিকা PDF এ দেখুন।</p><a class="link" href="#">PDF</a></div></li><li><div class="dot"></div><div class="card"><h3>Model Test Routine — HSC</h3><p>আসন্ন মডেল টেস্টের রুটিন ডাউনলোড করুন।</p><a class="link" href="#">Download</a></div></li><li><div class="dot"></div><div class="card"><h3>Science Fair Registration</h3><p>ক্লাস ৬–১২: Robotics, IoT, AI, Green Energy.</p><a class="link" href="#">Register</a></div></li></ol></div></section>
@@ -66,31 +78,101 @@
   <section id="leadership" class="section"><div class="wrap"><span class="section-tag">Leadership</span><div class="head"><h2>পরিচালনা পর্ষদ</h2><span class="muted">Student messages from leadership</span></div><div class="leaders"><article class="leader"><img src="https://dummyimage.com/560x700/0ea5e9/ffffff.png&text=Chief+Patron" alt="Chief Patron"><div class="info"><h4>Chief Patron</h4><p class="name">Brig. Gen. Name Here</p><a class="chip" href="#">Message</a></div></article><article class="leader"><img src="https://dummyimage.com/560x700/10b981/ffffff.png&text=Chairman" alt="Chairman"><div class="info"><h4>Chairman</h4><p class="name">Colonel Name Here</p><a class="chip" href="#">Message</a></div></article><article class="leader"><img src="https://dummyimage.com/560x700/6366f1/ffffff.png&text=Principal" alt="Principal"><div class="info"><h4>Principal</h4><p class="name">Mr./Ms. Name Here</p><a class="chip" href="#">Message</a></div></article></div></div></section>
   <div class="divider wave" aria-hidden="true"></div>
 
-  <section id="achievements" class="section"><div class="wrap"><span class="section-tag">Achievements</span><div class="head"><h2>অর্জনসমূহ</h2><span class="muted">Be a Champion</span></div><div class="counters"><div class="counter"><span data-count="38">0</span><label>Competition Trophies</label></div><div class="counter"><span data-count="12">0</span><label>Active Clubs</label></div><div class="counter"><span data-count="10000">0</span><label>Alumni+</label></div></div><div class="mt-6"><figure class="anim-caption"><figcaption>Achievements</figcaption><div id="lottie-trophy" class="lottie small"></div></figure></div></div></section>
+  <section id="achievements" class="section"><div class="wrap"><span class="section-tag">Achievements</span><div class="head"><div class="title"><h2>অর্জনসমূহ</h2></div><span class="muted">Be a Champion</span></div><div class="counters"><div class="counter"><span data-count="38">0</span><label>Competition Trophies</label></div><div class="counter"><span data-count="12">0</span><label>Active Clubs</label></div><div class="counter"><span data-count="120">0</span><label>Total Teachers</label></div></div><div class="mt-6 flex flex-col md:flex-row items-center gap-6"><img class="rounded-xl shadow" src="https://dummyimage.com/600x360/ffe4e6/1e293b.png&text=Champion+Team" alt="Champion team"></div></div></section>
   <div class="divider wave flip" aria-hidden="true"></div>
 
-  <section id="academics" class="section"><div class="wrap"><span class="section-tag">Academics</span><div class="head"><h2>পড়াশোনা</h2><span class="muted">Curriculum • HSC • ICT</span></div><div class="grid cards"><article class="card pop"><h3>Curriculum</h3><p>Grade 6–10 • HSC Science, Commerce, Arts.</p></article><article id="resources" class="card pop"><h3>Resources</h3><p>Syllabus & Notes (PDF), Question Bank, e-Library.</p></article><article class="card pop"><h3>Exams</h3><p>Term Exams, Model Tests, Practicals, Results.</p></article></div></div></section>
+  <section id="academics" class="section"><div class="wrap"><span class="section-tag">Academics</span><div class="head"><div class="title"><h2>পড়াশোনা</h2></div><span class="muted">Curriculum • HSC • ICT</span></div><div class="grid cards"><article class="card pop"><h3>Curriculum</h3><p>Grade 6–10 • HSC Science, Commerce, Arts.</p></article><article id="resources" class="card pop"><h3>Resources</h3><p>Syllabus & Notes (PDF), Question Bank, e-Library.</p></article><article class="card pop"><h3>Exams</h3><p>Term Exams, Model Tests, Practicals, Results.</p></article></div></div></section>
 
   <section id="cocurricular" class="section"><div class="wrap"><span class="section-tag">Activities</span><div class="head"><h2>সহ-পাঠ্য কার্যক্রম</h2></div><div class="grid cards"><article class="card pop"><h3>Debate</h3><ul class="bul"><li>Critical thinking</li><li>Public speaking</li></ul></article><article class="card pop"><h3>Sports</h3><ul class="bul"><li>Football, Cricket</li><li>Table Tennis, Chess</li></ul></article><article class="card pop"><h3>Cultural</h3><ul class="bul"><li>Music & Drama</li><li>Recitation</li></ul></article></div></div></section>
   <section id="clubs" class="section"><div class="wrap"><span class="section-tag">Clubs & Societies</span><div class="grid cards"><article class="card"><h3>Science Club</h3><ul class="bul"><li>Robotics, IoT</li><li>Science fairs</li></ul></article><article class="card"><h3>Language Club</h3><ul class="bul"><li>Bangla & English</li><li>Writing & debate</li></ul></article><article class="card"><h3>Photography</h3><ul class="bul"><li>Workshops</li><li>Campus stories</li></ul></article></div></div></section>
 
-  <section id="brain" class="section"><div class="wrap"><span class="section-tag">Fun + Logic</span><div class="head"><h2>Brain Challenge — চালাকি প্রশ্ন</h2><span class="muted">Think fast. Trickier than they look.</span></div><div class="quiz card"><div id="qText" class="qtext"></div><div id="qOptions" class="qopts"></div><div class="qactions"><button id="btnHint" class="ghost">Hint</button><button id="btnExplain" class="ghost">Explain</button><button id="btnNext" class="cta">Next</button></div><div class="qmeta">Question <span id="qNum">1</span>/<span id="qTotal">8</span> • Score: <span id="qScore">0</span></div></div></div></section>
+  <section id="brain" class="section"><div class="wrap"><span class="section-tag">Fun + Logic</span><div class="head"><div class="title"><h2>Brain Challenge — চালাকি প্রশ্ন</h2></div><span class="muted">Think fast. Trickier than they look.</span></div><div class="quiz card"><div id="qText" class="qtext"></div><div id="qOptions" class="qopts"></div><div class="qactions"><button id="btnHint" class="ghost">Hint</button><button id="btnExplain" class="ghost">Explain</button><button id="btnNext" class="cta">Next</button></div><div class="qmeta">Question <span id="qNum">1</span>/<span id="qTotal">8</span> • Score: <span id="qScore">0</span></div></div></div></section>
 
   <section id="gallery" class="section"><div class="wrap"><span class="section-tag">Gallery</span><div class="head"><h2>গ্যালারি</h2></div><div class="gallery-block"><h3 class="gtitle">Events</h3><div class="strip loop" data-speed="40"><img src="https://dummyimage.com/480x280/ffd6a5/1e293b.png&text=Annual+Day" alt="Annual Day"><img src="https://dummyimage.com/480x280/b4f8c8/1e293b.png&text=Science+Fair" alt="Science Fair"><img src="https://dummyimage.com/480x280/a0e7e5/1e293b.png&text=Cultural+Fest" alt="Cultural Fest"><img src="https://dummyimage.com/480x280/bee3f8/1e293b.png&text=Parade" alt="Parade"></div></div><div class="gallery-block"><h3 class="gtitle">Campus Life</h3><div class="strip loop" data-speed="45"><img src="https://dummyimage.com/480x280/e9d5ff/1e293b.png&text=Library" alt="Library"><img src="https://dummyimage.com/480x280/fde68a/1e293b.png&text=Classrooms" alt="Classrooms"><img src="https://dummyimage.com/480x280/fca5a5/1e293b.png&text=Assembly" alt="Assembly"><img src="https://dummyimage.com/480x280/bae6fd/1e293b.png&text=ICT+Lab" alt="ICT Lab"></div></div><div class="gallery-block"><h3 class="gtitle">Sports</h3><div class="strip loop" data-speed="35"><img src="https://dummyimage.com/480x280/c7d2fe/1e293b.png&text=Football" alt="Football"><img src="https://dummyimage.com/480x280/99f6e4/1e293b.png&text=Cricket" alt="Cricket"><img src="https://dummyimage.com/480x280/ddd6fe/1e293b.png&text=Table+Tennis" alt="Table Tennis"><img src="https://dummyimage.com/480x280/fde68a/1e293b.png&text=Chess" alt="Chess"></div></div></div></section>
 
   <section id="admission" class="section"><div class="wrap"><span class="section-tag">Admission</span><div class="head"><h2>ভর্তি</h2><span class="muted">Clear steps • Online apply</span></div><div class="cta-row"><a class="cta" href="#">Apply Online</a><a class="ghost" href="#">Instructions (PDF)</a></div></div></section>
   <section id="contact" class="section"><div class="wrap"><span class="section-tag">Contact</span><div class="head"><h2>যোগাযোগ</h2></div><div class="card"><p>Cumilla Cantonment 3501, Cumilla • Phone: 03239933170 • Mobile: 01733063001 • Email: ipscm1@gmail.com</p></div></div></section>
-  <footer class="footer"><div class="wrap"><div>© <span id="year"></span> IPSC, Cumilla.</div><div>Ultra v5 — clarity, ticker, looping galleries, improved quiz.</div></div></footer>
+  <footer class="footer"><div class="wrap"><div>© <span id="year"></span> Ispahani Cantonment Public School & College, Cumilla.</div></div></footer>
 
   <script>
     document.getElementById('year') && (document.getElementById('year').textContent = new Date().getFullYear());
     const mobileToggle=document.getElementById('mobileToggle'),mobileNav=document.getElementById('mobileNav');if(mobileToggle)mobileToggle.addEventListener('click',()=>mobileNav.classList.toggle('hidden'));
     document.querySelectorAll('.mega').forEach(m=>{let o,c;const open=()=>{clearTimeout(c);o=setTimeout(()=>m.classList.add('show'),140)},close=()=>{clearTimeout(o);c=setTimeout(()=>m.classList.remove('show'),140)};m.addEventListener('mouseenter',open);m.addEventListener('mouseleave',close)});
-    try{lottie.loadAnimation({container:document.getElementById('lottie-hero'),renderer:'svg',loop:true,autoplay:true,path:'https://assets2.lottiefiles.com/packages/lf20_ydo1amjm.json'});lottie.loadAnimation({container:document.getElementById('lottie-trophy'),renderer:'svg',loop:true,autoplay:true,path:'https://assets10.lottiefiles.com/packages/lf20_ikvz7qhc.json'});}catch(e){}
+    try{lottie.loadAnimation({container:document.getElementById('lottie-hero'),renderer:'svg',loop:true,autoplay:true,path:'https://assets2.lottiefiles.com/packages/lf20_ydo1amjm.json'});}catch(e){}
     (function(){const track=document.getElementById('tickerTrack');if(!track)return;track.innerHTML=track.innerHTML+track.innerHTML;})();
     const counters=document.querySelectorAll('.counter span[data-count]');const io=new IntersectionObserver(es=>{es.forEach(e=>{if(e.isIntersecting){const el=e.target,end=parseInt(el.dataset.count,10);let cur=0;const step=Math.ceil(end/80);const T=setInterval(()=>{cur+=step;if(cur>=end){cur=end;clearInterval(T)}el.textContent=cur.toLocaleString();},16);io.unobserve(el);}})},{threshold:.4});counters.forEach(c=>io.observe(c));
     document.querySelectorAll('.strip.loop').forEach(strip=>{const kids=[...strip.children];kids.forEach(el=>strip.appendChild(el.cloneNode(true)));let pos=0;const speed=parseInt(strip.dataset.speed||'40',10);let last=null,paused=false;const step=t=>{if(last===null)last=t;const dt=(t-last)/1000;last=t;if(!paused){pos+=speed*dt;if(pos>=strip.scrollWidth/2)pos=0;strip.scrollLeft=pos}requestAnimationFrame(step)};strip.addEventListener('mouseenter',()=>paused=true);strip.addEventListener('mouseleave',()=>paused=false);requestAnimationFrame(step)});
+    gsap.from('.header',{y:-60,opacity:0,duration:.6});
+    const revealItems=document.querySelectorAll('.section,.card');
+    const io2=new IntersectionObserver(entries=>{entries.forEach(e=>{if(e.isIntersecting){gsap.to(e.target,{opacity:1,y:0,duration:.6});io2.unobserve(e.target);}})},{threshold:.2});
+    revealItems.forEach(el=>{gsap.set(el,{opacity:0,y:40});io2.observe(el);});
     const modeToggle=document.getElementById('modeToggle');if(modeToggle){modeToggle.addEventListener('click',()=>document.documentElement.classList.toggle('dark'));}
+    const repoOwner='YOUR_GITHUB_USERNAME',repoName='ICPSC-Site',branch='main';
+    let token='',loggedIn=false,editing=false;
+    const editToggle=document.getElementById('editToggle'),saveBtn=document.getElementById('saveBtn'),loginModal=document.getElementById('loginModal'),loginOk=document.getElementById('loginOk'),loginCancel=document.getElementById('loginCancel'),tokenInput=document.getElementById('tokenInput');
+    if(editToggle){
+      const textSel='h1,h2,h3,h4,p,span,label';
+      function imgChooser(e){
+        const target=e.target;
+        const input=document.createElement('input');
+        input.type='file';input.accept='image/*';
+        input.onchange=()=>{
+          const file=input.files[0];
+          if(!file)return;
+          const reader=new FileReader();
+          reader.onload=ev=>{
+            const img=new Image();
+            img.onload=()=>{
+              const canvas=document.createElement('canvas');
+              canvas.width=target.clientWidth;
+              canvas.height=target.clientHeight;
+              const ctx=canvas.getContext('2d');
+              ctx.drawImage(img,0,0,canvas.width,canvas.height);
+              target.src=canvas.toDataURL('image/png');
+            };
+            img.src=ev.target.result;
+          };
+          reader.readAsDataURL(file);
+        };
+        input.click();
+      }
+      function toggleEditing(){
+        editing=!editing;
+        document.documentElement.classList.toggle('editing',editing);
+        document.querySelectorAll(textSel).forEach(el=>{
+          editing?el.setAttribute('contenteditable','true'):el.removeAttribute('contenteditable');
+        });
+        document.querySelectorAll('img').forEach(img=>{
+          editing?img.addEventListener('click',imgChooser):img.removeEventListener('click',imgChooser);
+        });
+        saveBtn.classList.toggle('hidden',!editing);
+      }
+      async function saveChanges(){
+        const html=document.documentElement.outerHTML;
+        const content=btoa(unescape(encodeURIComponent(html)));
+        const api=`https://api.github.com/repos/${repoOwner}/${repoName}/contents/index.html`;
+        const get=await fetch(api+`?ref=${branch}`,{headers:{Authorization:`token ${token}`}});
+        const data=await get.json();
+        const res=await fetch(api,{method:'PUT',headers:{Authorization:`token ${token}`,'Content-Type':'application/json'},body:JSON.stringify({message:'Update via onsite editor',content,sha:data.sha,branch})});
+        if(res.ok){alert('Saved to GitHub');toggleEditing();}else alert('Save failed');
+      }
+      editToggle.addEventListener('click',()=>{
+        if(!loggedIn){loginModal.classList.remove('hidden');return;}
+        toggleEditing();
+      });
+      saveBtn.addEventListener('click',saveChanges);
+      loginOk.addEventListener('click',async()=>{
+        token=tokenInput.value.trim();
+        if(!token)return;
+        const res=await fetch('https://api.github.com/user',{headers:{Authorization:`token ${token}`}});
+        if(res.ok){
+          const info=await res.json();
+          if(info.login!==repoOwner){alert('Not authorized');return;}
+          loggedIn=true;loginModal.classList.add('hidden');toggleEditing();
+        }else alert('Invalid token');
+      });
+      loginCancel.addEventListener('click',()=>loginModal.classList.add('hidden'));
+    }
   </script>
 
   <script>


### PR DESCRIPTION
## Summary
- Remove decorative stickers and oversized trophy from achievements, academics, and Brain Challenge sections
- Improve dark mode legibility and swap alumni counter for total teachers
- Add an edit mode button to modify text, logos, and gallery images directly on the page
- Require admin login for editing, offer save button, and push changes to GitHub with fixed-size image uploads

## Testing
- `npx -y htmlhint --rules '{"tagname-lowercase": false}' index.html`


------
https://chatgpt.com/codex/tasks/task_e_68b97d512af0832bafc79ee7db194f99