### PR TITLE
Fix dropdown menu hover issues and initial header gap

### DIFF
--- a/components/common.css
+++ b/components/common.css
@@ -1,6 +1,7 @@
     :root{--ink:#0f172a;--muted:#475569;--brand-red:#7f1d1d;--brand-green:#14532d;--link:var(--brand-green);--mast-h:0}
     html{scroll-behavior:smooth}
     html,body{overflow-x:hidden}
+    .hidden{display:none}
     [id]{scroll-margin-top:calc(var(--mast-h,0) + 1rem)}
     *{box-sizing:border-box}body{font-family:"Noto Sans Bengali","Inter",ui-sans-serif,-apple-system;line-height:1.5;padding-top:var(--mast-h,0);background:#f8fafc;background-image:radial-gradient(circle at 20% 20%,rgba(127,29,29,.08),transparent 60%),radial-gradient(circle at 80% 80%,rgba(20,83,45,.08),transparent 60%);background-attachment:fixed;}
     .wrap{max-width:1200px;margin:0 auto;padding:0 1rem}
@@ -17,7 +18,7 @@
     .nav{display:none;gap:.25rem;align-items:center;flex:1;justify-content:flex-end}@media(min-width:768px){.nav{display:flex}}.nav-btn{padding:.5rem .75rem;border-radius:.75rem;font-weight:700}
     .nav-btn.icon{padding:.5rem;font-size:1.25rem;line-height:1}
     .mega>.nav-btn::after{content:"\25BE";margin-left:.25rem;font-size:.65em;display:inline-block;transition:transform .2s}
-    .mega:hover>.nav-btn::after{transform:rotate(180deg)}
+    .mega.open>.nav-btn::after{transform:rotate(180deg)}
     .cta{padding:.55rem 1rem;border-radius:.8rem;font-weight:800;text-decoration:none;box-shadow:0 4px 8px rgba(2,6,23,.08);color:#fff}
     .cta.green{background:linear-gradient(135deg,var(--brand-green),#1e7a3f)}
     .cta.red{background:linear-gradient(135deg,var(--brand-red),#b91c1c)}
@@ -38,15 +39,16 @@
     .mega .panel .col h4{font-weight:800;font-size:.85rem;margin-bottom:.3rem}
     .mega .panel .col a{display:block;padding:.25rem .5rem;border-radius:.5rem;text-decoration:none;color:var(--ink)}
     .mega .panel .col a:hover{background:#f1f5f9}
-    .mega:hover .panel{display:grid}
+    .mega.open .panel{display:grid}
     .nav-btn:hover,.nav-btn:focus{background:#e2e8f0}
     .ticker{background:var(--brand-red);color:#fff;border-bottom:1px solid #991b1b}
     .ticker .wrap{overflow:hidden}
     .ticker-track{display:flex;gap:2rem;white-space:nowrap;animation:t 26s linear infinite}
     .ticker:hover .ticker-track{animation-play-state:paused}
     .tick{color:#ffe4e6;text-decoration:none;padding:.5rem 0}
+    #masthead.menu-open .ticker{pointer-events:none}
     @keyframes t{from{transform:translateX(0)}to{transform:translateX(-50%)}}
-    .section{padding:2.2rem 0}.head{display:flex;align-items:center;justify-content:space-between;gap:1rem;margin:.8rem 0}.head h2{font-size:1.6rem;font-weight:900}.head .title{display:flex;align-items:center;gap:.5rem}.muted{color:#64748b}.section-tag{display:inline-block;font-size:.75rem;font-weight:800;color:var(--brand-red);background:#fee2e2;border:1px solid #fecaca;border-radius:.5rem;padding:.15rem .5rem}.welcome-tag{display:block;margin:0 auto;text-align:center;font-size:1.25rem}
+    .section{padding:2.2rem 0}.head{display:flex;align-items:center;justify-content:space-between;gap:1rem;margin:.8rem 0}.head h2{font-size:1.6rem;font-weight:900}.head .title{display:flex;align-items:center;gap:.5rem}.muted{color:#64748b}.section-tag{display:inline-block;font-size:.75rem;font-weight:800;color:var(--brand-red);background:#fee2e2;border:1px solid #fecaca;border-radius:.5rem;padding:.15rem .5rem}.welcome-tag{display:block;margin:0 auto;text-align:center;font-size:1.5rem}
     .display{font-size:clamp(1rem,5vw,3rem);font-weight:900;letter-spacing:-.02em}.grad{background:linear-gradient(120deg,var(--brand-red),var(--brand-green));-webkit-background-clip:text;color:transparent}.lede{margin-top:.6rem;color:#475569;max-width:58ch}.btns{margin-top:1rem;display:flex;gap:.6rem;flex-wrap:wrap;justify-content:center}
     .hero{position:relative;overflow:hidden;isolation:isolate;padding:3rem 0}
     .hero::before{content:"";position:absolute;inset:0;background:url('../assets/background.png') center/cover no-repeat;opacity:.25;mix-blend-mode:multiply;pointer-events:none}

--- a/components/common.js
+++ b/components/common.js
@@ -23,32 +23,45 @@ if(document.readyState==='loading'){
 function initCommon(){
   const year=document.getElementById('year');
   if(year) year.textContent=new Date().getFullYear();
-  const setOffsets=()=>{
-    const mast=document.getElementById('masthead'),r=document.documentElement;
-    if(mast) r.style.setProperty('--mast-h',mast.offsetHeight+'px');
-  };
+  const mast=document.getElementById('masthead'),r=document.documentElement;
+  const updateMast=()=>{if(mast) r.style.setProperty('--mast-h',mast.offsetHeight+'px');};
+  updateMast();
+  if(mast){
+    new ResizeObserver(updateMast).observe(mast);
+    window.addEventListener('load',updateMast);
+  }
   const mobileNav=document.getElementById('mobileNav');
   const handleResize=()=>{
     if(window.innerWidth>=768 && mobileNav && !mobileNav.classList.contains('hidden')) mobileNav.classList.add('hidden');
-    setOffsets();
+    updateMast();
   };
-  setOffsets();
-  window.addEventListener('load',setOffsets);
   window.addEventListener('resize',handleResize);
   const mobileToggle=document.getElementById('mobileToggle');
   if(mobileToggle && mobileNav){
-    mobileToggle.addEventListener('click',()=>{mobileNav.classList.toggle('hidden');setOffsets();});
-    mobileNav.querySelectorAll('a').forEach(a=>a.addEventListener('click',()=>{mobileNav.classList.add('hidden');setOffsets();}));
+    mobileToggle.addEventListener('click',()=>{mobileNav.classList.toggle('hidden');updateMast();});
+    mobileNav.querySelectorAll('a').forEach(a=>a.addEventListener('click',()=>{mobileNav.classList.add('hidden');updateMast();}));
     mobileNav.querySelectorAll('.mhead').forEach(btn=>{
       btn.addEventListener('click',()=>{
         const sub=btn.nextElementSibling;
         mobileNav.querySelectorAll('.msub').forEach(s=>{if(s!==sub){s.classList.remove('open');s.previousElementSibling.classList.remove('open');}});
         sub.classList.toggle('open');
         btn.classList.toggle('open');
-        setOffsets();
+        updateMast();
       });
     });
   }
+  document.querySelectorAll('.mega').forEach(m=>{
+    const panel=m.querySelector('.panel');
+    let t;
+    const open=()=>{clearTimeout(t);m.classList.add('open');if(mast) mast.classList.add('menu-open');};
+    const close=()=>{t=setTimeout(()=>{m.classList.remove('open');if(!document.querySelector('.mega.open') && mast) mast.classList.remove('menu-open');},150);};
+    if(panel){
+      m.addEventListener('mouseenter',open);
+      m.addEventListener('mouseleave',close);
+      panel.addEventListener('mouseenter',open);
+      panel.addEventListener('mouseleave',close);
+    }
+  });
   const msgModal=document.getElementById('msgModal'),msgText=document.getElementById('msgText'),msgClose=document.getElementById('msgClose');
   if(msgModal && msgClose){
     msgClose.addEventListener('click',()=>msgModal.classList.add('hidden'));
@@ -91,7 +104,7 @@ function initCommon(){
   const loginModal=document.getElementById('loginModal'),loginNav=document.getElementById('loginNav'),loginNavM=document.getElementById('loginNavM'),loginOk=document.getElementById('loginOk'),loginCancel=document.getElementById('loginCancel');
   function openLogin(e){e.preventDefault();loginModal.classList.remove('hidden');}
   if(loginNav) loginNav.addEventListener('click',openLogin);
-  if(loginNavM) loginNavM.addEventListener('click',e=>{openLogin(e);if(mobileNav) mobileNav.classList.add('hidden');setOffsets();});
+    if(loginNavM) loginNavM.addEventListener('click',e=>{openLogin(e);if(mobileNav) mobileNav.classList.add('hidden');updateMast();});
   if(loginCancel) loginCancel.addEventListener('click',()=>loginModal.classList.add('hidden'));
   if(loginOk) loginOk.addEventListener('click',()=>loginModal.classList.add('hidden'));
 }

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
   <div id="decor"></div>
 <div id="header"></div>
 
-<section class="hero" id="overview"><div class="wrap text-center flex flex-col items-center"><span class="section-tag welcome-tag">Overview</span><h1 class="display whitespace-nowrap">Enter To Learn, <span class="grad">Leave To Serve</span></h1><p class="lede">Descipline • Lead • Character — Ispahani Cantonment Public School & College ক্যাম্পাসে প্রযুক্তিতে সমৃদ্ধ শিক্ষানুভূতি।</p><div class="btns"><a class="cta green" href="#admission">Apply Now</a><a class="cta red" href="#notices">Learn More</a></div></div></section>
+<section class="hero" id="overview"><div class="wrap text-center flex flex-col items-center"><span class="section-tag welcome-tag">Welcome</span><h1 class="display whitespace-nowrap">Enter To Learn, <span class="grad">Leave To Serve</span></h1><p class="lede">Descipline • Lead • Character — Ispahani Cantonment Public School & College ক্যাম্পাসে প্রযুক্তিতে সমৃদ্ধ শিক্ষানুভূতি।</p><div class="btns"><a class="cta green" href="#admission">Apply Now</a><a class="cta red" href="#notices">Learn More</a></div></div></section>
   <div class="divider wave" aria-hidden="true"></div>
 
   <section id="notices" class="section"><div class="wrap"><div class="head"><h2>Notices</h2><a class="link" href="#">সব নোটিশ →</a></div><ol class="timeline"><li><div class="dot"></div><div class="card"><h3>একাদশ শ্রেণিতে ভর্তি বিজ্ঞপ্তি (২০২৫–২০২৬)</h3><p>নির্ধারিত সময়ের মধ্যে অনলাইনে আবেদন করুন। প্রয়োজনীয় কাগজপত্রের তালিকা PDF এ দেখুন।</p><a class="link" href="#">PDF</a></div></li><li><div class="dot"></div><div class="card"><h3>Model Test Routine — HSC</h3><p>আসন্ন মডেল টেস্টের রুটিন ডাউনলোড করুন।</p><a class="link" href="#">Download</a></div></li><li><div class="dot"></div><div class="card"><h3>Science Fair Registration</h3><p>ক্লাস ৬–১২: Robotics, IoT, AI, Green Energy.</p><a class="link" href="#">Register</a></div></li></ol></div></section>
@@ -28,7 +28,37 @@
 
   <section id="academics" class="section"><div class="wrap"><div class="head"><h2>Academics</h2><span class="muted">Curriculum • HSC • ICT</span></div><div class="grid cards"><article class="card pop"><h3>Curriculum</h3><p>Grade 6–10 • HSC Science, Commerce, Arts.</p></article><article id="resources" class="card pop"><h3>Resources</h3><p>Syllabus & Notes (PDF), Question Bank, e-Library.</p></article><article class="card pop"><h3>Exams</h3><p>Term Exams, Model Tests, Practicals, Results.</p></article></div></div></section>
 
-  <section id="houses" class="section"><div class="wrap"><div class="head"><h2>Houses</h2></div><p class="muted">Details coming soon.</p></div></section>
+  <section id="houses" class="section">
+    <div class="wrap">
+      <div class="head"><h2>Houses</h2></div>
+      <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 justify-items-center">
+        <div class="w-40 h-40 sm:w-48 sm:h-48 md:w-56 md:h-56 bg-red-600 text-white rounded-xl shadow-lg shadow-black/40 flex flex-col">
+          <div class="flex-1 flex items-center justify-center p-2">
+            <img src="assets/houses/red.png" alt="Nazrul Islam" class="max-h-full max-w-full object-contain">
+          </div>
+          <div class="text-center p-2 font-semibold text-sm">Nazrul Islam House</div>
+        </div>
+        <div class="w-40 h-40 sm:w-48 sm:h-48 md:w-56 md:h-56 bg-green-600 text-white rounded-xl shadow-lg shadow-black/40 flex flex-col">
+          <div class="flex-1 flex items-center justify-center p-2">
+            <img src="assets/houses/green.png" alt="Qudrat E Khuda" class="max-h-full max-w-full object-contain">
+          </div>
+          <div class="text-center p-2 font-semibold text-sm">Qudrat E Khuda House</div>
+        </div>
+        <div class="w-40 h-40 sm:w-48 sm:h-48 md:w-56 md:h-56 bg-yellow-500 text-white rounded-xl shadow-lg shadow-black/40 flex flex-col">
+          <div class="flex-1 flex items-center justify-center p-2">
+            <img src="assets/houses/yellow.png" alt="Fozlul Haque" class="max-h-full max-w-full object-contain">
+          </div>
+          <div class="text-center p-2 font-semibold text-sm">Fozlul Haque House</div>
+        </div>
+        <div class="w-40 h-40 sm:w-48 sm:h-48 md:w-56 md:h-56 bg-orange-600 text-white rounded-xl shadow-lg shadow-black/40 flex flex-col">
+          <div class="flex-1 flex items-center justify-center p-2">
+            <img src="assets/houses/orange.png" alt="Begum Rokeya" class="max-h-full max-w-full object-contain">
+          </div>
+          <div class="text-center p-2 font-semibold text-sm">Begum Rokeya House</div>
+        </div>
+      </div>
+    </div>
+  </section>
   <section id="classes" class="section"><div class="wrap"><div class="head"><h2>Classes</h2></div><p class="muted">Details coming soon.</p></div></section>
   <section id="facilities" class="section"><div class="wrap"><div class="head"><h2>Facilities</h2></div><p class="muted">Labs, library, playgrounds and more.</p></div></section>
 


### PR DESCRIPTION
## Summary
- Update masthead offset in real time with a ResizeObserver to remove initial gap under the notice bar
- Disable ticker pointer events while dropdown menus are open to prevent accidental hover
- Add base `.hidden` utility to keep mobile navigation collapsed before Tailwind loads
- Replace "Overview" banner with a larger "Welcome" tag
- Add four color-coded house cards referencing assets for future photos
- Deepen house card colors, center portraits with padding, and enlarge card size on larger screens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb73200650832b9ee66e483e20d801